### PR TITLE
Add Rails 6 support

### DIFF
--- a/lib/sendgrid-rails.rb
+++ b/lib/sendgrid-rails.rb
@@ -3,4 +3,6 @@ require 'active_support'
 require 'active_support/core_ext'
 require 'action_mailer'
 
-ActionMailer::Base.send :include, SendGrid
+ActiveSupport.on_load(:action_mailer) do
+  ActionMailer::Base.send :include, SendGrid
+end


### PR DESCRIPTION
This is a fix for the Rails 6 upgrade warning:
```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.
```